### PR TITLE
Fix template ckan version check

### DIFF
--- a/ckanext/hierarchy/templates/organization/snippets/organization_tree.html
+++ b/ckanext/hierarchy/templates/organization/snippets/organization_tree.html
@@ -14,7 +14,7 @@ Example:
 
 #}
 
-{% set type = 'asset' if h.check_ckan_version(min_version='2.10') else 'resource' %}
+{% set type = 'asset' if h.check_ckan_version(min_version='2.9') else 'resource' %}
 {% include 'hierarchy/snippets/hierarchy_' ~ type ~ '.html' %}
 
 <ul class="hierarchy-tree-top">

--- a/ckanext/hierarchy/templates/organization/snippets/organization_tree.html
+++ b/ckanext/hierarchy/templates/organization/snippets/organization_tree.html
@@ -14,7 +14,7 @@ Example:
 
 #}
 
-{% set type = 'asset' if h.ckan_version() > '2.9' else 'resource' %}
+{% set type = 'asset' if h.check_ckan_version(min_version='2.10') else 'resource' %}
 {% include 'hierarchy/snippets/hierarchy_' ~ type ~ '.html' %}
 
 <ul class="hierarchy-tree-top">


### PR DESCRIPTION
## Description
* `h.ckan_version()` in [ckanext/hierarchy/templates/organization/snippets/organization_tree.html](https://github.com/ckan/ckanext-hierarchy/compare/master...dbca-wa:ckanext-hierarchy:51-templates#diff-ad1911805f6c105a866c5994a39ef94c7b026c64db65e2d8c03a3e36e1216838) fails to recognise "2.10.0a0" as "2.10"
* `h.check_ckan_version(min_version="2.10")` works as expected: true for CKAN 2.10+ including "2.10.0a0", false for CKAN <= 2.9
* HT @wardi for advice in gitter CKAN chat
* Edit: s Adrià pointed out, the correct cut-over is to use `resource` up until CKAN 2.8 and `asset` from CKAN 2.9 onwards, so the `min_version` should be 2.9.

## Related
* Closes #51 
* https://github.com/ckan/ckan/issues/6787 tracks CKAN 2.10 upgrade
* https://github.com/ckan/ckanext-hierarchy/pull/49 does not (yet) include the changes of this PR and will likely fail on CKAN version "2.10.0a0"

## Testing
Verified locally with CKAN via docker-compose using an upgrade [Dockerfile](https://github.com/dbca-wa/ckan/blob/dbca2022/Dockerfile#L102) following the upgraded [docker-compose docs](https://github.com/dbca-wa/ckan/blob/dbca2022/doc/maintaining/installing/install-from-docker-compose.rst).

Manage org
![image](https://user-images.githubusercontent.com/762815/179697128-0aa7a0cf-49cd-4a14-9dc4-f9227e4a4264.png)

Show org
![image](https://user-images.githubusercontent.com/762815/179697291-34767665-1324-49d0-9a59-56f775e940ad.png)

Org datasets
![image](https://user-images.githubusercontent.com/762815/179697360-dd673e7a-d592-4703-8c3e-a554691b7656.png)
