### PR TITLE
Convert tests to pytest

### DIFF
--- a/ckanext/hierarchy/tests/fixtures.py
+++ b/ckanext/hierarchy/tests/fixtures.py
@@ -1,8 +1,11 @@
+import pytest
+
 from ckan.tests import factories
 from ckan import model
 
 
-def create_fixtures():
+@pytest.fixture
+def initial_data():
     parent_org = factories.Organization(name='parent_org', title='Parent')
     child_org = factories.Organization(name='child_org', title='child')
     member = model.Member(

--- a/ckanext/hierarchy/tests/test_plugin.py
+++ b/ckanext/hierarchy/tests/test_plugin.py
@@ -1,8 +1,6 @@
 import pytest
 from bs4 import BeautifulSoup
 
-from ckan.tests import helpers
-
 from common import create_fixtures
 
 

--- a/ckanext/hierarchy/tests/test_plugin.py
+++ b/ckanext/hierarchy/tests/test_plugin.py
@@ -1,7 +1,7 @@
 import pytest
 from bs4 import BeautifulSoup
 
-from common import create_fixtures
+from .common import create_fixtures
 
 
 @pytest.mark.usefixtures('clean_db', 'clean_index')

--- a/ckanext/hierarchy/tests/test_plugin.py
+++ b/ckanext/hierarchy/tests/test_plugin.py
@@ -1,15 +1,13 @@
 import pytest
 from bs4 import BeautifulSoup
 
-from .common import create_fixtures
-
 
 @pytest.mark.usefixtures('clean_db', 'clean_index')
 class TestOrgPage():
 
-    def test_search_parent_including_children(self, app):
+    def test_search_parent_including_children(self, initial_data, app):
         parent_org, child_org, parent_dataset, child_dataset = \
-            create_fixtures()
+            initial_data()
 
         response = app.get(
             url='/organization/parent_org?include_children=True')
@@ -17,9 +15,9 @@ class TestOrgPage():
         search_results = scrape_search_results(response)
         assert search_results == set(('parent', 'child'))
 
-    def test_search_parent_excluding_children(self, app):
+    def test_search_parent_excluding_children(self, initial_data, app):
         parent_org, child_org, parent_dataset, child_dataset = \
-            create_fixtures()
+            initial_data()
 
         response = app.get(
             url='/organization/parent_org')
@@ -27,9 +25,9 @@ class TestOrgPage():
         search_results = scrape_search_results(response)
         assert search_results == set(('parent',))
 
-    def test_search_child_including_children(self, app):
+    def test_search_child_including_children(self, initial_data, app):
         parent_org, child_org, parent_dataset, child_dataset = \
-            create_fixtures()
+            initial_data()
 
         response = app.get(
             url='/organization/child_org?include_children=True')

--- a/ckanext/hierarchy/tests/test_plugin.py
+++ b/ckanext/hierarchy/tests/test_plugin.py
@@ -7,7 +7,7 @@ class TestOrgPage():
 
     def test_search_parent_including_children(self, initial_data, app):
         parent_org, child_org, parent_dataset, child_dataset = \
-            initial_data()
+            initial_data
 
         response = app.get(
             url='/organization/parent_org?include_children=True')
@@ -17,7 +17,7 @@ class TestOrgPage():
 
     def test_search_parent_excluding_children(self, initial_data, app):
         parent_org, child_org, parent_dataset, child_dataset = \
-            initial_data()
+            initial_data
 
         response = app.get(
             url='/organization/parent_org')
@@ -27,7 +27,7 @@ class TestOrgPage():
 
     def test_search_child_including_children(self, initial_data, app):
         parent_org, child_org, parent_dataset, child_dataset = \
-            initial_data()
+            initial_data
 
         response = app.get(
             url='/organization/child_org?include_children=True')

--- a/ckanext/hierarchy/tests/test_plugin.py
+++ b/ckanext/hierarchy/tests/test_plugin.py
@@ -1,47 +1,43 @@
-import nose.tools
+import pytest
 from bs4 import BeautifulSoup
 
 from ckan.tests import helpers
 
 from common import create_fixtures
 
-eq = nose.tools.assert_equals
 
+@pytest.mark.usefixtures('clean_db', 'clean_index')
+class TestOrgPage():
 
-class TestOrgPage(helpers.FunctionalTestBase):
-
-    def test_search_parent_including_children(self):
+    def test_search_parent_including_children(self, app):
         parent_org, child_org, parent_dataset, child_dataset = \
             create_fixtures()
 
-        app = self._get_test_app()
         response = app.get(
             url='/organization/parent_org?include_children=True')
 
         search_results = scrape_search_results(response)
-        eq(search_results, set(('parent', 'child')))
+        assert search_results == set(('parent', 'child'))
 
-    def test_search_parent_excluding_children(self):
+    def test_search_parent_excluding_children(self, app):
         parent_org, child_org, parent_dataset, child_dataset = \
             create_fixtures()
 
-        app = self._get_test_app()
         response = app.get(
             url='/organization/parent_org')
 
         search_results = scrape_search_results(response)
-        eq(search_results, set(('parent',)))
+        assert search_results == set(('parent',))
 
-    def test_search_child_including_children(self):
+    def test_search_child_including_children(self, app):
         parent_org, child_org, parent_dataset, child_dataset = \
             create_fixtures()
 
-        app = self._get_test_app()
         response = app.get(
             url='/organization/child_org?include_children=True')
 
         search_results = scrape_search_results(response)
-        eq(search_results, set(('child',)))
+        assert search_results == set(('child',))
 
 
 def scrape_search_results(response):

--- a/ckanext/hierarchy/tests/test_unaffected.py
+++ b/ckanext/hierarchy/tests/test_unaffected.py
@@ -1,20 +1,15 @@
 '''Tests that this extension doesn't break unrelated things'''
 
-from builtins import object
-import nose.tools
-
+import pytest
 from ckan.tests import helpers
 
 from common import create_fixtures
 
-eq = nose.tools.assert_equals
 
+@pytest.mark.usefixtures('clean_db', 'clean_index')
+class TestSearchApi():
 
-class TestSearchApi(object):
-    def setup(self):
-        helpers.reset_db()
-
-    def test_package_search_is_unaffected(self):
+    def test_package_search_is_unaffected(self, app):
         parent_org, child_org, parent_dataset, child_dataset = \
             create_fixtures()
 
@@ -26,16 +21,14 @@ class TestSearchApi(object):
         search_results = \
             [result['name'] for result in package_search_result['results']]
 
-        eq(set(search_results), set(('parent',)))
+        assert set(search_results) == set(('parent',))
 
 
-class TestPages(helpers.FunctionalTestBase):
-    def setup(self):
-        helpers.reset_db()
+@pytest.mark.usefixtures('clean_db', 'clean_index')
+class TestPages():
 
-    def test_home_page(self):
+    def test_home_page(self, app):
         parent_org, child_org, parent_dataset, child_dataset = \
             create_fixtures()
 
-        app = self._get_test_app()
         app.get(url='/')

--- a/ckanext/hierarchy/tests/test_unaffected.py
+++ b/ckanext/hierarchy/tests/test_unaffected.py
@@ -3,7 +3,7 @@
 import pytest
 from ckan.tests import helpers
 
-from common import create_fixtures
+from .common import create_fixtures
 
 
 @pytest.mark.usefixtures('clean_db', 'clean_index')

--- a/ckanext/hierarchy/tests/test_unaffected.py
+++ b/ckanext/hierarchy/tests/test_unaffected.py
@@ -3,15 +3,13 @@
 import pytest
 from ckan.tests import helpers
 
-from .common import create_fixtures
-
 
 @pytest.mark.usefixtures('clean_db', 'clean_index')
 class TestSearchApi():
 
-    def test_package_search_is_unaffected(self, app):
+    def test_package_search_is_unaffected(self, initial_data, app):
         parent_org, child_org, parent_dataset, child_dataset = \
-            create_fixtures()
+            initial_data()
 
         # package_search API is unaffected by ckanext-hierarchy (only searches
         # via the front-end are affected)
@@ -27,8 +25,8 @@ class TestSearchApi():
 @pytest.mark.usefixtures('clean_db', 'clean_index')
 class TestPages():
 
-    def test_home_page(self, app):
+    def test_home_page(self, initial_data, app):
         parent_org, child_org, parent_dataset, child_dataset = \
-            create_fixtures()
+            initial_data()
 
         app.get(url='/')

--- a/ckanext/hierarchy/tests/test_unaffected.py
+++ b/ckanext/hierarchy/tests/test_unaffected.py
@@ -9,7 +9,7 @@ class TestSearchApi():
 
     def test_package_search_is_unaffected(self, initial_data, app):
         parent_org, child_org, parent_dataset, child_dataset = \
-            initial_data()
+            initial_data
 
         # package_search API is unaffected by ckanext-hierarchy (only searches
         # via the front-end are affected)
@@ -27,6 +27,6 @@ class TestPages():
 
     def test_home_page(self, initial_data, app):
         parent_org, child_org, parent_dataset, child_dataset = \
-            initial_data()
+            initial_data
 
         app.get(url='/')

--- a/conftest.py
+++ b/conftest.py
@@ -1,0 +1,5 @@
+# -*- coding: utf-8 -*-
+
+pytest_plugins = [
+    u'ckanext.hierarchy.tests.fixtures',
+]


### PR DESCRIPTION
Tests are failing on 2.9+ as the extension does not yet actually work on latest ckan yet.