### PR TITLE
Prepare for CKAN 2.10

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -7,7 +7,7 @@ jobs:
       - uses: actions/checkout@v3
       - uses: actions/setup-python@v2
         with:
-          python-version: '3.6'
+          python-version: '3.8'
       - name: Install requirements
         run: pip install flake8 pycodestyle
       - name: Check syntax
@@ -63,4 +63,4 @@ jobs:
         run: |
           paster --plugin=ckan db init -c test.ini
       - name: Run tests
-        run: pytest --ckan-ini=test.ini --cov=ckanext.hierarchy --disable-warnings ckanext/hierarchy/tests
+        run: pytest --ckan-ini=test.ini -v --cov=ckanext.hierarchy --disable-warnings ckanext/hierarchy/tests

--- a/ckanext/hierarchy/templates/organization/snippets/organization_tree.html
+++ b/ckanext/hierarchy/templates/organization/snippets/organization_tree.html
@@ -14,9 +14,8 @@ Example:
 
 #}
 
-{% set ckan_min_ver = 'asset' if h.ckan_version().split('.')[1] | int %}
-<h1>CKAN VER {{ ckan_min_ver }} </h1>
-{% set file_type = 'asset' if ckan_min_ver >= 9 else 'resource' %}
+{% set ckan_min_ver = h.ckan_version().split('.')[1] %}
+{% set file_type = 'asset' if ckan_min_ver|int >= 9 else 'resource' %}
 {% include 'hierarchy/snippets/hierarchy_' ~ file_type ~ '.html' %}
 
 <ul class="hierarchy-tree-top">

--- a/ckanext/hierarchy/templates/organization/snippets/organization_tree.html
+++ b/ckanext/hierarchy/templates/organization/snippets/organization_tree.html
@@ -14,8 +14,10 @@ Example:
 
 #}
 
-{% set type = 'asset' if h.ckan_version().split('.')[1] | int >= 9 else 'resource' %}
-{% include 'hierarchy/snippets/hierarchy_' ~ type ~ '.html' %}
+{% set ckan_min_ver = 'asset' if h.ckan_version().split('.')[1] | int %}
+<h1>CKAN VER {{ ckan_min_ver }} </h1>
+{% set file_type = 'asset' if ckan_min_ver >= 9 else 'resource' %}
+{% include 'hierarchy/snippets/hierarchy_' ~ file_type ~ '.html' %}
 
 <ul class="hierarchy-tree-top">
   {% for node in top_nodes recursive %}

--- a/ckanext/hierarchy/templates/snippets/search_form.html
+++ b/ckanext/hierarchy/templates/snippets/search_form.html
@@ -7,6 +7,6 @@
     {{ super() }}
     {% if include_children_option %}
         {% set group_type = c.group_dict.type.title() %}
-        {{ form.checkbox('include_children', label="Include Sub-"+group_type, checked=(h.is_include_children_selected()), value=True, error=error) }}
+        {{ form.checkbox('include_children', label="Include Sub-"+group_type+"s", checked=(h.is_include_children_selected()), value=True, error=error) }}
     {% endif %}
 {% endblock %}

--- a/ckanext/hierarchy/templates/snippets/search_form.html
+++ b/ckanext/hierarchy/templates/snippets/search_form.html
@@ -6,8 +6,7 @@
 {% block search_input %}
     {{ super() }}
     {% if include_children_option %}
-        {% if c.group_dict.type == "organization" %}{% set group_type = "Organizations"%}{% endif %}
-        {% if c.group_dict.type == "group" %}{% set group_type = "Groups"%}{% endif %}
+        {% set group_type = c.group_dict.type.title() %}
         {{ form.checkbox('include_children', label="Include Sub-"+group_type, checked=(h.is_include_children_selected()), value=True, error=error) }}
     {% endif %}
 {% endblock %}

--- a/ckanext/hierarchy/tests/test_plugin.py
+++ b/ckanext/hierarchy/tests/test_plugin.py
@@ -44,7 +44,7 @@ class TestOrgPage():
             status=200,
         )
 
-        assert child_org["title"] in response.body
+        assert str(child_org["title"]) in response.body
 
     def test_org_home(self, initial_data, app):
         """ Test the org home view works and show the child org """
@@ -55,7 +55,7 @@ class TestOrgPage():
             status=200,
         )
 
-        assert child_org["title"] in response.body
+        assert str(child_org["title"]) in response.body
 
 
 def scrape_search_results(response):

--- a/ckanext/hierarchy/tests/test_plugin.py
+++ b/ckanext/hierarchy/tests/test_plugin.py
@@ -35,6 +35,28 @@ class TestOrgPage():
         search_results = scrape_search_results(response)
         assert search_results == set(('child',))
 
+    def test_org_about(self, initial_data, app):
+        """ Test the about view works and show the child org """
+        parent_org, child_org, _, _ = initial_data
+
+        response = app.get(
+            url='/organization/about/%s' % parent_org["name"],
+            status=200,
+        )
+
+        assert child_org["title"] in response.body
+
+    def test_org_home(self, initial_data, app):
+        """ Test the org home view works and show the child org """
+        parent_org, child_org, _, _ = initial_data
+
+        response = app.get(
+            url='/organization/%s' % parent_org["name"],
+            status=200,
+        )
+
+        assert child_org["title"] in response.body
+
 
 def scrape_search_results(response):
     try:


### PR DESCRIPTION
Fixes #60 

This PR:
 - Fixes the error detecting ckan min version for CKAN 2.10
 - Allow to use custom group types
 - Update action to use proper python version


