### PR TITLE
Avoid CKAN 2.10 deprecation

### DIFF
--- a/ckanext/hierarchy/groups_hierarchy/group/read.html
+++ b/ckanext/hierarchy/groups_hierarchy/group/read.html
@@ -27,5 +27,5 @@
         (_('Last Modified'), 'metadata_modified desc'),
         (_('Popular'), 'views_recent desc') if g.tracking_enabled else (false, false) ]
     %}
-    {% snippet 'snippets/search_form.html', form_id='group-datasets-search-form', type='dataset', query=q, sorting=sorting, sorting_selected=sort_by_selected, count=page.item_count, facets=facets, placeholder=_('Search datasets...'), show_empty=request.params, fields=fields, include_children_option=true %}
+    {% snippet 'snippets/search_form.html', form_id='group-datasets-search-form', type='dataset', query=q, sorting=sorting, sorting_selected=sort_by_selected, count=page.item_count, facets=facets, placeholder=_('Search datasets...'), show_empty=request.args, fields=fields, include_children_option=true %}
 {% endblock %}

--- a/ckanext/hierarchy/helpers.py
+++ b/ckanext/hierarchy/helpers.py
@@ -1,6 +1,6 @@
 import ckan.plugins as p
 import ckan.model as model
-from ckan.common import request, is_flask_request
+from ckan.common import request
 
 
 def group_tree(organizations=[], type_='organization'):
@@ -115,7 +115,14 @@ def get_allowable_parent_groups(group_id):
 
 def is_include_children_selected():
     include_children_selected = False
-    if is_flask_request():
-        if request.params.get('include_children'):
+
+    if p.toolkit.check_ckan_version(min_version="2.10"):
+        is_flask = True
+    else:
+        from ckan.common import is_flask_request
+        is_flask = is_flask_request()
+
+    if is_flask:
+        if request.args.get('include_children'):
             include_children_selected = True
     return include_children_selected

--- a/ckanext/hierarchy/templates/organization/read.html
+++ b/ckanext/hierarchy/templates/organization/read.html
@@ -27,5 +27,5 @@
         (_('Last Modified'), 'metadata_modified desc'),
         (_('Popular'), 'views_recent desc') if g.tracking_enabled else (false, false) ]
     %}
-    {% snippet 'snippets/search_form.html', form_id='organization-datasets-search-form', type='dataset', query=q, sorting=sorting, sorting_selected=sort_by_selected, count=page.item_count, facets=facets, placeholder=_('Search datasets...'), show_empty=request.params, fields=fields, include_children_option=true %}
+    {% snippet 'snippets/search_form.html', form_id='organization-datasets-search-form', type='dataset', query=q, sorting=sorting, sorting_selected=sort_by_selected, count=page.item_count, facets=facets, placeholder=_('Search datasets...'), show_empty=request.args, fields=fields, include_children_option=true %}
 {% endblock %}


### PR DESCRIPTION
Log messages from CKAN 2.10

_Function params() in module ckan.common has been deprecated since CKAN v2.10.0 and will be removed in a later release of ckan. Use request.args_

Also

_Function is_flask_request() in module ckan.common has been deprecated since CKAN v2.10.0 and will be removed in a later release of ckan. All web requests are served by Flask_

This PR updates these calls