### PR TITLE
Add new template location for CKAN 2.11

### DIFF
--- a/ckanext/hierarchy/templates/organization/snippets/info.html
+++ b/ckanext/hierarchy/templates/organization/snippets/info.html
@@ -1,10 +1,5 @@
 {% ckan_extends %}
 
-{#
-    For CKAN 2.11, the location of this template was moved to templates/organization/snippets/info.html
-    We preserve this file for backwards compatibility.
-#}
-
 {% if group_dict is not defined %}{% set group_dict = c.group_dict %}{% endif %}
 
 {% block heading %}


### PR DESCRIPTION
CKAN 2.11 moved the file `templates/snippets/organization.html` to `templates/organization/snippets/info.html` 

We add here the new template and preserve the old version only for backwards compatibility