### PR TITLE
CKAN 2.12 support

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -19,7 +19,7 @@ jobs:
     needs: lint
     strategy:
       matrix:
-        ckan-version: ["2.11", "2.10"]
+        ckan-version: ["2.12", "2.11", "2.10"]
       fail-fast: false
 
     name: CKAN ${{ matrix.ckan-version }}


### PR DESCRIPTION
Testing the latest default branch against the ckan/ckan-dev:2.12 image to surface any potential issues